### PR TITLE
Enables support to specify the region.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,21 @@ nodes:
   i-00000003: 10.0.2.1
 ```
 
-Optional properties include:
+Optional properties include (Values shown are the defaults):
 ```yaml
 pings: 3
 ping_timeout: 1
 heartbeat_interval: 10
 ```
+
+Optional AWS configuration include:
+```yaml
+aws_access_key_id: YOUR ACCESS KEY
+aws_secret_access_key: YOUR SECRET KEY
+region: us-east-1
+```
+Note that:
+  - If you don't specify the aws credentials it will use the IAM role of the instance
 
 ## Contributing
 

--- a/lib/nat-monitor.rb
+++ b/lib/nat-monitor.rb
@@ -114,13 +114,9 @@ module EtTools
           options = { use_iam_profile: true }
         end
 
-        if @conf['region']
-          options[:region] = @conf['region']
-        else
-          output "It is recommended to specify a region on the config_file because by default is us-east-1"
-        end
-
+        options[:region] = @conf['region'] if @conf['region']
         options[:endpoint] = @conf['aws_url'] if @conf['aws_url']
+
         Fog::Compute::AWS.new(options)
       end
     end

--- a/lib/nat-monitor.rb
+++ b/lib/nat-monitor.rb
@@ -114,6 +114,12 @@ module EtTools
           options = { use_iam_profile: true }
         end
 
+        if @conf['region']
+          options[:region] = @conf['region']
+        else
+          output "It is recommended to specify a region on the config_file because by default is us-east-1"
+        end
+
         options[:endpoint] = @conf['aws_url'] if @conf['aws_url']
         Fog::Compute::AWS.new(options)
       end


### PR DESCRIPTION
By default the gem fog-aws is using the region 'us-east-1' as we could see here:
https://github.com/fog/fog-aws/blob/master/lib/fog/aws/compute.rb#L302

If I specify the endpoint: https://ec2.eu-west-1.amazonaws.com, (the region is 'us-east-1', as we have seen) then the connection returns OK but when I try to list the route table ruby throws an exception because the endpoint and region are not matching.

If the user didn't specify the region I will let him know that by default he is using 'us-east-1'

Comments are more than welcome.
Thanks.